### PR TITLE
internals: add path completion w tests

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.24
+current_version = 0.0.25
 commit = True
 
 [bumpversion:file:setup.py]

--- a/bibo/bibo.py
+++ b/bibo/bibo.py
@@ -24,11 +24,13 @@ FILE_OPTIONS = internals.combine_decorators([
         '--file',
         help='File to link to this entry.',
         type=click.Path(exists=True, readable=True, dir_okay=False),
+        autocompletion=internals.complete_path,
     ),
     click.option(
         '--destination',
         help='A folder to put the file in.',
         type=click.Path(exists=True, readable=True, dir_okay=True, file_okay=False),
+        autocompletion=internals.complete_path,
     ),
     click.option(
         '--no-copy',
@@ -56,7 +58,8 @@ SEARCH_TERMS_OPTION = click.argument(
 @click.group(help=__doc__)
 @click.version_option()
 @click.option('--database', envvar=internals.BIBO_DATABASE_ENV_VAR,
-              help='A .bib file.', required=True, type=PATH_OPTION)
+              help='A .bib file.', required=True, type=PATH_OPTION,
+              autocompletion=internals.complete_path)
 @click.pass_context
 def cli(ctx, database):
     ctx.ensure_object(dict)

--- a/bibo/internals.py
+++ b/bibo/internals.py
@@ -188,7 +188,6 @@ def complete_path(ctx, args, incomplete):
     wildc_path = os.path.expanduser(os.path.expandvars(incomplete)) + '*'
     options = []
     for path in glob.glob(wildc_path):
-        if not os.access(path, os.R_OK):
-            continue
-        options.append((path, os.path.basename(path)))
+        if os.access(path, os.R_OK):
+            options.append((path, os.path.basename(path)))
     return options

--- a/bibo/internals.py
+++ b/bibo/internals.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import collections
+import glob
 import itertools
 import os
 import re
@@ -177,3 +178,17 @@ def bib_entries(entries):
 def unique_key_validation(new_key, data):
     if new_key in (e['key'] for e in bib_entries(data)):
         raise click.ClickException('Duplicate key, command aborted')
+
+
+def complete_path(ctx, args, incomplete):
+    '''
+    Autocompletion for files, matches the glob of incomplete argument, and
+    provide basename prompts.
+    '''
+    wildc_path = os.path.expanduser(os.path.expandvars(incomplete)) + '*'
+    options = []
+    for path in glob.glob(wildc_path):
+        if not os.access(path, os.R_OK):
+            continue
+        options.append((path, os.path.basename(path)))
+    return options

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='bibo',
-    version='0.0.24',
+    version='0.0.25',
     description='Command line reference manager with single source of truth: the .bib file. Inspired by beets',
     long_description=long_description,
     url='https://github.com/Nagasaki45/bibo',

--- a/tests/bibo/test_internals.py
+++ b/tests/bibo/test_internals.py
@@ -43,3 +43,30 @@ def test_format_entry(data):
     entry = data[0]
     assert internals.format_entry(entry, '$year') == '1937'
     assert internals.format_entry(entry, '$year: $title') == '1937: The Hobbit'
+
+def test_complete_path(tmpdir):
+    # Create dummy files and a sub-dir with file
+    ps = []
+    for i in range(10):
+        name = 'even' if i % 2 else 'odd'
+        p = tmpdir / "journal{}_{}.txt".format(name, i)
+        p.write(i)
+        ps.append(p)
+    n_top_level_journals = len(ps)
+    subp = tmpdir.mkdir("subdir").join("subjournal.txt")
+    subp.write('findme')
+    assert len(tmpdir.listdir()) == 1 + n_top_level_journals
+
+    incomplete = lambda paths: os.path.join(tmpdir.strpath, *paths)
+
+    # Check all matches incl subdir
+    matches = internals.complete_path(None, None, incomplete(['']))
+    assert len(matches) == 1 + n_top_level_journals
+    # Check match pattern
+    ms_even = internals.complete_path(None, None, incomplete(['journaleven']))
+    assert len(ms_even) == n_top_level_journals // 2
+    # Check subdir match
+    ms_subdir = internals.complete_path(None, None, incomplete(['subdir', '']))
+    assert len(ms_subdir) == 1
+    # Check for completion help string as basename
+    assert ms_subdir[0] == (subp.strpath, subp.basename)


### PR DESCRIPTION
As per '_Autocompletion broke completion for paths (file, destination, database)_' https://github.com/Nagasaki45/bibo/issues/38

Any input would be appreciated, or style/whatever guidelines for the repo (does that information exist anywhere?) I haven't written tests in a bit too long....

This works, but looks a bit messy for deep directories (long paths) or long file names etc. At least it works!

