### PR TITLE
internals: avoid SameFileError on shutil copy

### DIFF
--- a/bibo/internals.py
+++ b/bibo/internals.py
@@ -111,8 +111,10 @@ def set_file(data, entry, file_, destination=None, no_copy=False):
     basename = string_to_basename(entry['key'])
     path = os.path.join(destination, basename + file_extension)
     entry['fields']['file'] = path
-    click.echo('Copying {} to {}'.format(file_, path))
-    shutil.copy(file_, path)
+    # Potentially, path exists already (and was simply passed as relative)
+    if not os.path.isfile(path):
+        click.echo('Copying {} to {}'.format(file_, path))
+        shutil.copy(file_, path)
 
 
 def editor(*args, **kwargs):

--- a/tests/bibo/test_internals.py
+++ b/tests/bibo/test_internals.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 import click
 import pytest
@@ -33,6 +34,19 @@ def test_set_file_with_destination(data, example_pdf, tmpdir):
     internals.set_file(data, entry, example_pdf, str(destination))
     assert os.path.exists(str(destination / entry['key'] + '.pdf'))
 
+def test_set_file_exists_already(data, example_pdf, tmpdir):
+    entry = data[0]
+    # Create an existing pdf, specified by user as relative path
+    ext = os.path.splitext(example_pdf)[1]
+    dest = tmpdir / 'subdir'
+    os.mkdir(dest.strpath)
+    existing_pdf = shutil.copyfile(example_pdf, dest.join(entry['key'] + ext))
+    relative_file = os.path.join('subdir', os.path.basename(existing_pdf))
+    with tmpdir.as_cwd():
+        try:
+            internals.set_file(data, entry, relative_file, dest.strpath)
+        except shutil.SameFileError as e:
+            pytest.fail('Raised {}'.format(repr(e)))
 
 def test_get_database():
     args = ['whatever', '--database', 'test.bib', 'whatever']


### PR DESCRIPTION
As per '_Add command with --file fails if the file is already in the right place_': https://github.com/Nagasaki45/bibo/issues/53

Previously, passing a relative path to existing file with `bibo add --file` caused `shutil` to raise an error on copy. `internals.set_file` correctly expands the target path of the file relative to the destination/database, but simply should avoid a copy if the file exists already.
