### PR TITLE
Highlight search match

### DIFF
--- a/bibo/bibo.py
+++ b/bibo/bibo.py
@@ -105,7 +105,8 @@ def list_(ctx, search_term, raw, bibstyle, verbose, **kwargs):
     format_pattern = kwargs.pop("format")
     assert not kwargs
 
-    entries = query.search(ctx.obj["data"], search_term)
+    results = query.search(ctx.obj["data"], search_term)
+    entries = (r.entry for r in results)
     if raw:
         _list_raw(entries)
     elif format_pattern:
@@ -171,7 +172,7 @@ def open_(ctx, search_term):
     This command fails if the number of entries that match the search is
     different than one.
     """
-    entry = query.get(ctx.obj["data"], search_term)
+    entry = query.get(ctx.obj["data"], search_term).entry
 
     for field_name in ["file", "url", "doi"]:
         value = entry.get("fields", {}).get(field_name)

--- a/bibo/internals.py
+++ b/bibo/internals.py
@@ -200,13 +200,16 @@ def complete_path(ctx, args, incomplete):
     return options
 
 
+def bold(s: str) -> str:
+    """Return `s` wrapped in ANSI bold."""
+    return "{}{}{}".format(_ANSI_BOLD, s, _ANSI_UNBOLD)
+
+
 def highlight_text(text, highlight):
     """
     Return `text` with sub-string `highlight` in bold.
     """
-    text = re.sub(
-        highlight, "{}{}{}".format(_ANSI_BOLD, highlight, _ANSI_UNBOLD), text,
-    )
+    text = re.sub(highlight, bold(highlight), text)
     # Drop ANSI unbold followed by ANSI bold
     return text.replace(_ANSI_UNBOLD + _ANSI_BOLD, "")
 

--- a/bibo/internals.py
+++ b/bibo/internals.py
@@ -7,6 +7,7 @@ import itertools
 import os
 import re
 import shutil
+import typing
 
 import click
 
@@ -224,7 +225,7 @@ def highlight_text(text, highlight):
 
 def highlight_match(
     text: str, result: models.SearchResult, extra_match_info: dict = None
-):
+) -> typing.Tuple[str, dict]:
     """
     Highlight `text` with `result.match` info. Every bit of info that is in
     `result.match` but not in `text` is added to the `extra_match_info` to

--- a/bibo/internals.py
+++ b/bibo/internals.py
@@ -224,7 +224,14 @@ def highlight_text(text, highlight):
     return text.replace(_ansi_unbold + _ansi_bold, "")
 
 
-def highlight_match(text, result, extra_match_info=None):
+def highlight_match(
+    text: str, result: models.SearchResult, extra_match_info: dict = None
+):
+    """
+    Highlight `text` with `result.match` info. Every bit of info that is in
+    `result.match` but not in `text` is added to the `extra_match_info` to
+    present to the user.
+    """
     if extra_match_info is None:
         extra_match_info = {}
     for key, vals in result.match.items():

--- a/bibo/internals.py
+++ b/bibo/internals.py
@@ -200,18 +200,6 @@ def complete_path(ctx, args, incomplete):
     return options
 
 
-def match_case(substring, target):
-    """
-    Return the string `substring` with the same case as in the `target`
-    string.
-    """
-    index = target.lower().find(substring.lower())
-    if index < 0:
-        msg = "Failed to match case: {} not in {}".format(substring, target)
-        raise ValueError(msg)
-    return target[index : (index + len(substring))]
-
-
 def highlight_text(text, highlight):
     """
     Return `text` with sub-string `highlight` in bold.

--- a/bibo/internals.py
+++ b/bibo/internals.py
@@ -15,6 +15,8 @@ import pybibs
 from . import models
 
 BIBO_DATABASE_ENV_VAR = "BIBO_DATABASE"
+_ANSI_BOLD = "\033[1m"
+_ANSI_UNBOLD = "\033[22m"
 
 
 def header(entry):
@@ -209,19 +211,15 @@ def match_case(substring, target):
     return target[index : (index + len(substring))]
 
 
-_ansi_bold = "\033[1m"
-_ansi_unbold = "\033[22m"
-
-
 def highlight_text(text, highlight):
     """
     Return `text` with sub-string `highlight` in bold.
     """
     text = re.sub(
-        highlight, "{}{}{}".format(_ansi_bold, highlight, _ansi_unbold), text,
+        highlight, "{}{}{}".format(_ANSI_BOLD, highlight, _ANSI_UNBOLD), text,
     )
     # Drop ANSI unbold followed by ANSI bold
-    return text.replace(_ansi_unbold + _ansi_bold, "")
+    return text.replace(_ANSI_UNBOLD + _ANSI_BOLD, "")
 
 
 def highlight_match(

--- a/bibo/internals.py
+++ b/bibo/internals.py
@@ -192,3 +192,15 @@ def complete_path(ctx, args, incomplete):
         if os.access(path, os.R_OK):
             options.append((path, os.path.basename(path)))
     return options
+
+
+def match_case(substring, target):
+    """
+    Return the string `substring` with the same case as in the `target`
+    string.
+    """
+    index = target.lower().find(substring.lower())
+    if index < 0:
+        msg = "Failed to match case: {} not in {}".format(substring, target)
+        raise ValueError(msg)
+    return target[index : (index + len(substring))]

--- a/bibo/models.py
+++ b/bibo/models.py
@@ -1,0 +1,3 @@
+import collections
+
+SearchResult = collections.namedtuple("SearchResult", ["entry", "match"])

--- a/bibo/query.py
+++ b/bibo/query.py
@@ -1,13 +1,15 @@
 import collections
 import collections.abc
 import itertools
+import re
+import typing
 
 import click
 
 from . import internals, models
 
 
-def search(data, search_terms):
+def search(data, search_terms: typing.Iterable[str]):
     if isinstance(search_terms, str):
         search_terms = [search_terms]
     search_terms = iter(search_terms)
@@ -27,47 +29,50 @@ def _recursive_search(results, search_terms):
         return results
 
 
-def _match(entry, search_term):
+def _match(entry, search_term: str):
     """
     Return a similar structure to an entry (nested dict) with matching strings
     as values.
     """
-    d = collections.defaultdict(dict)
+    d: typing.Dict[str, typing.Any] = {}
 
     # For cases where the entire search term is a key (e.g. best:author)
-    if search_term.lower() in entry["key"].lower():
-        d["key"] = internals.match_case(search_term, entry["key"])
+    matches = re.findall(search_term, entry["key"], re.IGNORECASE)
+    if matches:
+        d.setdefault("key", set()).update(matches)
 
     search_field, search_value = _parse_search_term(search_term)
 
     for part in ["key", "type"]:
         if search_field and search_field != part:
             continue
-        if search_value in entry[part].lower():
-            d[part] = internals.match_case(search_value, entry[part])
+        matches = re.findall(search_value, entry[part], re.IGNORECASE)
+        if matches:
+            d.setdefault(part, set()).update(matches)
     for field, value in entry.get("fields", {}).items():
         if search_field and search_field != field:
             continue
-        if search_value in value.lower():
-            d["fields"][field] = internals.match_case(search_value, value)
+        matches = re.findall(search_value, value, re.IGNORECASE)
+        if matches:
+            d.setdefault("fields", {}).setdefault(field, set()).update(matches)
     return d
 
 
 def _update_result(result, new_match):
     if not new_match:
         return None
-    d = _nested_append(result.match, new_match)
+    d = _nested_update(result.match, new_match)
     return models.SearchResult(result.entry, d)
 
 
-def _nested_append(d, u):
+def _nested_update(d, u):
     _d = d.copy()
     for k, v in u.items():
         if isinstance(v, collections.abc.Mapping):
-            _d[k] = _nested_append(d.get(k, {}), v)
+            _d[k] = _nested_update(d.get(k, {}), v)
         else:
-            _d[k] = _d.get(k, [])
-            _d[k].append(v)
+            _d[k] = _d.get(k, set())
+            _d[k].update(v)
     return _d
 
 

--- a/bibo/query.py
+++ b/bibo/query.py
@@ -32,12 +32,14 @@ def _match(entry, search_term):
     Return a similar structure to an entry (nested dict) with matching strings
     as values.
     """
+    d = collections.defaultdict(dict)
+
+    # For cases where the entire search term is a key (e.g. best:author)
     if search_term.lower() in entry["key"].lower():
-        return {"key": internals.match_case(search_term, entry["key"])}
+        d["key"] = internals.match_case(search_term, entry["key"])
 
     search_field, search_value = _parse_search_term(search_term)
 
-    d = collections.defaultdict(dict)
     for part in ["key", "type"]:
         if search_field and search_field != part:
             continue

--- a/bibo/query.py
+++ b/bibo/query.py
@@ -4,17 +4,14 @@ import itertools
 
 import click
 
-from . import internals
-
-
-SearchResult = collections.namedtuple("SearchResult", ["entry", "match"])
+from . import internals, models
 
 
 def search(data, search_terms):
     if isinstance(search_terms, str):
         search_terms = [search_terms]
     search_terms = iter(search_terms)
-    results = (SearchResult(e, {}) for e in internals.bib_entries(data))
+    results = (models.SearchResult(e, {}) for e in internals.bib_entries(data))
     return _recursive_search(results, search_terms)
 
 
@@ -58,7 +55,7 @@ def _update_result(result, new_match):
     if not new_match:
         return None
     d = _nested_append(result.match, new_match)
-    return SearchResult(result.entry, d)
+    return models.SearchResult(result.entry, d)
 
 
 def _nested_append(d, u):

--- a/bibo/query.py
+++ b/bibo/query.py
@@ -1,3 +1,5 @@
+import collections
+import collections.abc
 import itertools
 
 import click
@@ -5,77 +7,93 @@ import click
 from . import internals
 
 
+SearchResult = collections.namedtuple("SearchResult", ["entry", "match"])
+
+
 def search(data, search_terms):
     if isinstance(search_terms, str):
         search_terms = [search_terms]
     search_terms = iter(search_terms)
-    return _recursive_search(internals.bib_entries(data), search_terms)
+    results = (SearchResult(e, {}) for e in internals.bib_entries(data))
+    return _recursive_search(results, search_terms)
 
 
-def _recursive_search(data, search_terms):
+def _recursive_search(results, search_terms):
     try:
         search_term = next(search_terms)
-        return _recursive_search(
-            (e for e in data if _is_matching(e, search_term)), search_terms,
-        )
+        # Calculate match with search term and update results
+        results = (_update_result(r, _match(r.entry, search_term)) for r in results)
+        # Drop Nones with empty match
+        results = (r for r in results if r)
+        return _recursive_search(results, search_terms)
     except StopIteration:
-        return data
+        return results
 
 
-def _is_matching(entry, search_term):
+def _match(entry, search_term):
+    """
+    Return a similar structure to an entry (nested dict) with matching strings
+    as values.
+    """
+    if search_term.lower() in entry["key"].lower():
+        return {"key": internals.match_case(search_term, entry["key"])}
+
     search_field, search_value = _parse_search_term(search_term)
-    if search_field == "general":
-        return _is_matching_general_field(entry, search_value)
-    else:
-        if (search_field + ":" + search_value) in entry["key"].lower():
-            return True
-        return _is_matching_specific_field(entry, search_field, search_value)
 
-
-def _is_matching_general_field(entry, search_value):
-    searchables = itertools.chain(
-        entry.get("fields", {}).values(), (entry[x] for x in ["key", "type"]),
-    )
-
-    for searchable in searchables:
-        if search_value in searchable.lower():
-            return True
-    return False
-
-
-def _is_matching_specific_field(entry, search_field, search_value):
-    if search_field == "key":
-        return search_value in entry["key"].lower()
-    if search_field == "type":
-        return search_value in entry["type"].lower()
+    d = collections.defaultdict(dict)
+    for part in ["key", "type"]:
+        if search_field and search_field != part:
+            continue
+        if search_value in entry[part].lower():
+            d[part] = internals.match_case(search_value, entry[part])
     for field, value in entry.get("fields", {}).items():
-        if search_field == field.lower():
-            return search_value in value.lower()
-    return False
+        if search_field and search_field != field:
+            continue
+        if search_value in value.lower():
+            d["fields"][field] = internals.match_case(search_value, value)
+    return d
+
+
+def _update_result(result, new_match):
+    if not new_match:
+        return None
+    d = _nested_append(result.match, new_match)
+    return SearchResult(result.entry, d)
+
+
+def _nested_append(d, u):
+    _d = d.copy()
+    for k, v in u.items():
+        if isinstance(v, collections.abc.Mapping):
+            _d[k] = _nested_append(d.get(k, {}), v)
+        else:
+            _d[k] = _d.get(k, [])
+            _d[k].append(v)
+    return _d
 
 
 def _parse_search_term(search_term):
     parts = search_term.split(":")
     if len(parts) == 1:
-        return "general", parts[0].lower()
+        return None, parts[0].lower()
     if len(parts) == 2:
         return parts[0].lower(), parts[1].lower()
     raise click.ClickException("Invalid search term")
 
 
 def get(data, search_terms):
-    entries = list(search(data, search_terms))
+    results = list(search(data, search_terms))
 
-    for entry in entries:
-        if entry["key"].lower() == search_terms[0].lower():
-            return entry
+    for result in results:
+        if result.entry["key"].lower() == search_terms[0].lower():
+            return result
 
-    if len(entries) == 0:
+    if len(results) == 0:
         raise click.ClickException("No entries found")
-    if len(entries) > 1:
+    if len(results) > 1:
         raise click.ClickException("Multiple entries found")
 
-    return entries[0]
+    return results[0]
 
 
 def get_by_key(data, key):

--- a/tests/bibo/test_bibo.py
+++ b/tests/bibo/test_bibo.py
@@ -328,7 +328,7 @@ def test_edit_multiple_fields(runner, database):
 
     with open(database) as f:
         data = pybibs.read_string(f.read())
-        entry = bibo.query.get(data, "asimov")
+        entry = bibo.query.get(data, "asimov").entry
         assert entry["fields"]["title"] == "I, robot"
         assert entry["fields"]["year"] == "1950"
 

--- a/tests/bibo/test_bibo.py
+++ b/tests/bibo/test_bibo.py
@@ -80,6 +80,13 @@ def test_list_shows_only_bib_entries(runner, database):
         assert non_bib_type not in result.output
 
 
+def test_list_extra_match_info(runner, database):
+    args = ["--database", database, "list", "lotr.com"]
+    result = runner.invoke(bibo.cli, args)
+    assert "matched by" in result.output
+    assert "url: " in result.output
+
+
 def test_open(runner, database):
     with mock.patch("click.launch") as launch_mock:
         args = ["--database", database, "open", "tolkien1937"]

--- a/tests/bibo/test_internals.py
+++ b/tests/bibo/test_internals.py
@@ -78,16 +78,16 @@ def test_complete_path(tmpdir):
 
 def test_highlight_text():
     s1 = "hello world"
-    s2 = "hello {}w{}orld".format(internals._ANSI_BOLD, internals._ANSI_UNBOLD)
+    s2 = "hello {}orld".format(internals.bold("w"))
     assert internals.highlight_text(s1, "w") == s2
 
-    s3 = "hell{}o w{}orld".format(internals._ANSI_BOLD, internals._ANSI_UNBOLD)
+    s3 = "hell{}orld".format(internals.bold("o w"))
     assert internals.highlight_text(s2, "o ") == s3
 
 
 def test_highlight_text_with_color():
     s1 = "hello world"
-    s2 = "hello {}w{}orld".format(internals._ANSI_BOLD, internals._ANSI_UNBOLD)
+    s2 = "hello {}orld".format(internals.bold("w"))
     f = lambda s: click.style(s, fg="green")
     assert internals.highlight_text(f(s1), "w") == f(s2)
 
@@ -99,11 +99,5 @@ def test_highlight_match():
     result = models.SearchResult(entry, match)
 
     text, extra_match_info = internals.highlight_match(text, result)
-    assert text == "my name is {}Mosh{}e, 40".format(
-        internals._ANSI_BOLD, internals._ANSI_UNBOLD
-    )
-    assert extra_match_info == {
-        "address": "{}London{}, UK".format(
-            internals._ANSI_BOLD, internals._ANSI_UNBOLD
-        ),
-    }
+    assert text == "my name is {}e, 40".format(internals.bold("Mosh"))
+    assert extra_match_info == {"address": "{}, UK".format(internals.bold("London"))}

--- a/tests/bibo/test_internals.py
+++ b/tests/bibo/test_internals.py
@@ -85,16 +85,16 @@ def test_match_case():
 
 def test_highlight_text():
     s1 = "hello world"
-    s2 = "hello {}w{}orld".format(internals._ansi_bold, internals._ansi_unbold)
+    s2 = "hello {}w{}orld".format(internals._ANSI_BOLD, internals._ANSI_UNBOLD)
     assert internals.highlight_text(s1, "w") == s2
 
-    s3 = "hell{}o w{}orld".format(internals._ansi_bold, internals._ansi_unbold)
+    s3 = "hell{}o w{}orld".format(internals._ANSI_BOLD, internals._ANSI_UNBOLD)
     assert internals.highlight_text(s2, "o ") == s3
 
 
 def test_highlight_text_with_color():
     s1 = "hello world"
-    s2 = "hello {}w{}orld".format(internals._ansi_bold, internals._ansi_unbold)
+    s2 = "hello {}w{}orld".format(internals._ANSI_BOLD, internals._ANSI_UNBOLD)
     f = lambda s: click.style(s, fg="green")
     assert internals.highlight_text(f(s1), "w") == f(s2)
 
@@ -107,10 +107,10 @@ def test_highlight_match():
 
     text, extra_match_info = internals.highlight_match(text, result)
     assert text == "my name is {}Mosh{}e, 40".format(
-        internals._ansi_bold, internals._ansi_unbold
+        internals._ANSI_BOLD, internals._ANSI_UNBOLD
     )
     assert extra_match_info == {
         "address": "{}London{}, UK".format(
-            internals._ansi_bold, internals._ansi_unbold
+            internals._ANSI_BOLD, internals._ANSI_UNBOLD
         ),
     }

--- a/tests/bibo/test_internals.py
+++ b/tests/bibo/test_internals.py
@@ -76,13 +76,6 @@ def test_complete_path(tmpdir):
     assert ms_subdir[0] == (subp.strpath, subp.basename)
 
 
-def test_match_case():
-    assert internals.match_case("hello", "Hello World") == "Hello"
-    assert internals.match_case("WORLD", "Hello World") == "World"
-    with pytest.raises(ValueError):
-        internals.match_case("bibo", "Hello World")
-
-
 def test_highlight_text():
     s1 = "hello world"
     s2 = "hello {}w{}orld".format(internals._ANSI_BOLD, internals._ANSI_UNBOLD)

--- a/tests/bibo/test_internals.py
+++ b/tests/bibo/test_internals.py
@@ -74,3 +74,10 @@ def test_complete_path(tmpdir):
     assert len(ms_subdir) == 1
     # Check for completion help string as basename
     assert ms_subdir[0] == (subp.strpath, subp.basename)
+
+
+def test_match_case():
+    assert internals.match_case("hello", "Hello World") == "Hello"
+    assert internals.match_case("WORLD", "Hello World") == "World"
+    with pytest.raises(ValueError):
+        internals.match_case("bibo", "Hello World")

--- a/tests/bibo/test_query.py
+++ b/tests/bibo/test_query.py
@@ -1,7 +1,7 @@
 import click
 import pytest  # type: ignore
 
-from bibo import query
+from bibo import models, query
 
 
 def test_search_a_key_with_colon(data):
@@ -82,7 +82,7 @@ def test_update_result():
         "a": "1234",
         "props": {"b": "ABCD"},
     }
-    r1 = query.SearchResult(entry, {})
+    r1 = models.SearchResult(entry, {})
     assert query._update_result(r1, {}) == None
 
     r2 = query._update_result(r1, {"a": "1"})

--- a/tests/bibo/test_query.py
+++ b/tests/bibo/test_query.py
@@ -12,32 +12,32 @@ def test_search_a_key_with_colon(data):
 def test_search_single_term(data):
     results = list(query.search(data, ["asimov"]))
     assert len(results) == 1
-    assert results[0]["fields"]["title"] == "Foundation"
+    assert results[0].entry["fields"]["title"] == "Foundation"
 
 
 def test_search_multiple_search_terms(data):
     results = list(query.search(data, ["tolkien", "hobbit"]))
     assert len(results) == 1
-    assert results[0]["fields"]["title"] == "The Hobbit"
+    assert results[0].entry["fields"]["title"] == "The Hobbit"
 
 
 def test_search_specific_field(data):
     results = list(query.search(data, ["year:1937"]))
     assert len(results) == 1
-    assert results[0]["fields"]["title"] == "The Hobbit"
+    assert results[0].entry["fields"]["title"] == "The Hobbit"
 
 
 def test_search_specific_field_with_capital_letter(data):
     """Issue #27"""
     results = list(query.search(data, ["author:asimov"]))
     assert len(results) == 1
-    assert results[0]["fields"]["title"] == "Foundation"
+    assert results[0].entry["fields"]["title"] == "Foundation"
 
 
 def test_search_multiple_terms_are_anded(data):
     results = list(query.search(data, ["tolkien", "type:book"]))
     assert len(results) == 1
-    assert results[0]["fields"]["title"] == "The Hobbit"
+    assert results[0].entry["fields"]["title"] == "The Hobbit"
 
 
 def test_search_invalid_search_term(data):
@@ -49,10 +49,58 @@ def test_search_with_capitalized_search_term(data):
     """Issue #28"""
     results = list(query.search(data, ["ASIMOV"]))
     assert len(results) == 1
-    assert results[0]["fields"]["title"] == "Foundation"
+    assert results[0].entry["fields"]["title"] == "Foundation"
 
 
 def test_open_multiple_entries_one_exact_match(data):
     with pytest.raises(click.ClickException):
         query.get(data, ["ab"])
     query.get(data, ["abc"])
+
+
+def test_search_match_details(data):
+    results = list(query.search(data, ["tolkien", "hobbit"]))
+    assert len(results) == 1
+    assert "tolkien" in results[0].match["key"]
+    assert ("title", ["Hobbit"]) in results[0].match["fields"].items()
+
+
+def test_match(data):
+    entry = data[0]
+    assert query._match(entry, "Tolkien") == {"key": "tolkien"}
+    assert query._match(entry, "article") == {}
+    assert query._match(entry, "book") == {"type": "book"}
+    assert query._match(entry, "hobbit") == {
+        "fields": {"title": "Hobbit", "file": "hobbit"}
+    }
+    assert query._match(entry, "year:193") == {"fields": {"year": "193"}}
+    assert query._match(entry, "year:1937") == {"fields": {"year": "1937"}}
+
+
+def test_update_result():
+    entry = {
+        "a": "1234",
+        "props": {"b": "ABCD"},
+    }
+    r1 = query.SearchResult(entry, {})
+    assert query._update_result(r1, {}) == None
+
+    r2 = query._update_result(r1, {"a": "1"})
+    assert "a" in r2.match
+    assert r2.match["a"] == ["1"]
+
+    r3 = query._update_result(r2, {"props": {"b": "ABC"}})
+    assert r3.match["props"]["b"] == ["ABC"]
+
+    r4 = query._update_result(r3, {"props": {"b": "D"}})
+    assert r3.match["props"]["b"] == ["ABC", "D"]
+
+
+def test_nested_append():
+    d = {"x": {"y": ["z"]}}
+    u = {"x": {"y": "t"}}
+    assert query._nested_append(d, u) == {"x": {"y": ["z", "t"]}}
+
+    d = {}
+    u = {"x": "X"}
+    assert query._nested_append(d, u) == {"x": ["X"]}

--- a/tests/bibo/test_query.py
+++ b/tests/bibo/test_query.py
@@ -67,7 +67,10 @@ def test_search_match_details(data):
 
 def test_match(data):
     entry = data[0]
-    assert query._match(entry, "Tolkien") == {"key": "tolkien"}
+    assert query._match(entry, "Tolkien") == {
+        "key": "tolkien",
+        "fields": {"author": "Tolkien"},
+    }
     assert query._match(entry, "article") == {}
     assert query._match(entry, "book") == {"type": "book"}
     assert query._match(entry, "hobbit") == {


### PR DESCRIPTION
This is to solve issue #58.

The solution is based on two major changes, described below.

# Query returns `SearchResult`s

First the `query` module, instead of returning the matching entries, yields `models.SearchResult` objects. These got `entry` and `match` field. The entry is the usual dict. The match is a dict with a similar structure but with keys only for values that match the search and values that equal to the substring that was matched. For example, a match can look like this:
```
match = {
    "key": ["surname"],
    "fields": {
        "author": ["Mr", "Surname"],
        "title": ["complex", "model"],
    },
}
```
There are lists as values because multiple substring of an entry can match when using mutiple search terms, and we want to highlight all of them.

# Highlighting the `list` output

`bibo list` uses the `SearchResult`s to highlight the substring in the header / citation that matches the search, and if there are none, add include the fields that were matched in the output.