### PR TITLE
Handling entry types with capitalised letters

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.30
+current_version = 0.0.31
 commit = True
 
 [bumpversion:file:setup.py]

--- a/bibo/internals.py
+++ b/bibo/internals.py
@@ -178,7 +178,7 @@ def bib_entries(entries):
     Drop @string / @comment / @preamble entries.
     """
     for e in entries:
-        if e["type"] not in ["string", "comment", "preamble"]:
+        if e["type"].lower() not in ["string", "comment", "preamble"]:
             yield e
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = "2020, Tom Gurion"
 author = "Tom Gurion"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.30"
+release = "0.0.31"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pybibs/_internals.py
+++ b/pybibs/_internals.py
@@ -96,7 +96,7 @@ def parse_value(value):
 
 
 def write_entry(entry):
-    if entry["type"] == "string":
+    if entry["type"].lower() == "string":
         return write_string_entry(entry)
     elif entry["type"].lower() in ["comment", "preamble"]:
         return write_key_body_entry(entry)

--- a/pybibs/_internals.py
+++ b/pybibs/_internals.py
@@ -98,7 +98,7 @@ def parse_value(value):
 def write_entry(entry):
     if entry["type"] == "string":
         return write_string_entry(entry)
-    elif entry["type"] in ["comment", "preamble"]:
+    elif entry["type"].lower() in ["comment", "preamble"]:
         return write_key_body_entry(entry)
     else:
         return write_general_entry(entry)

--- a/pybibs/pybibs.py
+++ b/pybibs/pybibs.py
@@ -30,7 +30,7 @@ def read_entry_string(raw_entry):
     assert rest[-1] == "}"
     rest = rest[:-1]
 
-    if type_ == "string":
+    if type_.lower() == "string":
         k, v = next(_internals.parse_raw_key_values(rest))
         return {
             "type": "string",

--- a/pybibs/pybibs.py
+++ b/pybibs/pybibs.py
@@ -37,7 +37,7 @@ def read_entry_string(raw_entry):
             "key": k,
             "val": v,
         }
-    elif type_ in ["comment", "preamble"]:
+    elif type_.lower() in ["comment", "preamble"]:
         return {
             "type": type_,
             "body": rest,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, "README.rst"), encoding="utf-8") as f:
 
 setup(
     name="bibo",
-    version="0.0.30",
+    version="0.0.31",
     description="Command line reference manager with single source of truth: the .bib file. Inspired by beets",
     long_description=long_description,
     url="https://github.com/Nagasaki45/bibo",


### PR DESCRIPTION
This PR fixes #70. Briefly, the `comment` and `preamble` types were previously recognised only if the `@comment` or `@preamble` was denoted by lowercase letters. This made bib files generated by other libraries that use capitalised letters (for example `@Comment`) incompatible with bibo. The comparison is now done with the variable `type_` converted to lowercase.

This PR does not change the default behaviour of bibo.