### PR TITLE
Adding trailing commas for entries

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.30
+current_version = 0.0.31
 commit = True
 
 [bumpversion:file:setup.py]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = "2020, Tom Gurion"
 author = "Tom Gurion"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.30"
+release = "0.0.31"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pybibs/_internals.py
+++ b/pybibs/_internals.py
@@ -117,5 +117,5 @@ def write_general_entry(entry):
     parts += ["@", entry["type"], "{", entry["key"]]
     for k, v in entry["fields"].items():
         parts += [",\n", "  ", k, " = {", v, "}"]
-    parts.append("\n}")
+    parts.append(",\n}")
     return "".join(parts)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, "README.rst"), encoding="utf-8") as f:
 
 setup(
     name="bibo",
-    version="0.0.30",
+    version="0.0.31",
     description="Command line reference manager with single source of truth: the .bib file. Inspired by beets",
     long_description=long_description,
     url="https://github.com/Nagasaki45/bibo",

--- a/tests/pybibs/conftest.py
+++ b/tests/pybibs/conftest.py
@@ -9,13 +9,13 @@ def raw():
 @article{israel,
   author = {Israel, Moshe},
   title = {Article title},
-  year = {2008}
+  year = {2008},
 }
 
 @book{orwell,
   author = {Orwell, George},
   title = {1984},
-  year = {1949}
+  year = {1949},
 }
 """.strip()
 


### PR DESCRIPTION
This fixes #71. Briefly, trailing commas are added to all entries in the bib file for smaller git diffs. Trailing commas are also included in the raw data which is used to test the write functionality. 

This PR does change the default behaviour of bibo (all entries will now have a trailing comma).